### PR TITLE
Fixes the issue #5.

### DIFF
--- a/share-site-space-templates-repo/src/main/amp/config/alfresco/module/share-site-space-templates-repo/context/bootstrap-context.xml
+++ b/share-site-space-templates-repo/src/main/amp/config/alfresco/module/share-site-space-templates-repo/context/bootstrap-context.xml
@@ -17,7 +17,7 @@
         <property name="description"><value>share-site-space-templates-repo.folderBootstrap.description</value></property>
         <property name="fixesFromSchema"><value>0</value></property>
         <property name="fixesToSchema"><value>${version.schema}</value></property>
-        <property name="targetSchema"><value>10000</value></property>
+        <property name="targetSchema"><value>15000</value></property>
         <property name="importerBootstrap">
             <ref bean="spacesBootstrap" />
         </property>


### PR DESCRIPTION
I solved the problem setting the targetSchema to 15000.
The "default" value for targetSchema used to be 10000, but now that the Alfresco schema is already bigger than 10000, that value is no more useful.
By setting it to 15000 I was even able to install the addon into a 5.1.f.
